### PR TITLE
feat: produce Andrid compatible .aar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ Download/clone the repository, and with gradle setup run `./gradlew build` from 
 
 To only run the tests: `./gradlew test`.
 
+## Artifacts
+
+This repo builds both:
+
+- A JVM `.jar` (module `dP256`)
+- An Android `.aar` (module `dP256Android`)
+
+Build both:
+
+```bash
+./gradlew :dP256:build :dP256Android:assembleRelease
+```
+
+Outputs:
+
+- JVM jar: `dP256/build/libs/dP256-<version>.jar`
+- Android aar: `dP256Android/build/outputs/aar/dP256Android-release.aar`
+
+Note: if you use the `.aar` as a file dependency, Gradle will not automatically pull its transitive dependencies. If your app hits missing classes at compile/runtime, add the same dependencies declared in `dP256Android/build.gradle.kts` to your app.
+
 # LICENSE
 
 Copyright 2024 Algorand Foundation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    kotlin("jvm") version "1.9.0" apply false
+    id("base")
+    kotlin("jvm") version "1.9.22" apply false
+    kotlin("android") version "1.9.22" apply false
+    id("com.android.library") version "8.3.2" apply false
+}
+
+tasks.named("build") {
+    dependsOn(":dP256:build")
+    dependsOn(":dP256Android:assembleRelease")
 }

--- a/dP256Android/build.gradle.kts
+++ b/dP256Android/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+}
+
+group = "foundation.algorand"
+version = "1.0-SNAPSHOT"
+
+android {
+    namespace = "foundation.algorand.deterministicP256"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    // Reuse the existing JVM module sources so we don't duplicate code.
+    sourceSets {
+        getByName("main") {
+            java.srcDirs("../dP256/src/main/kotlin")
+            resources.srcDirs("../dP256/src/main/resources")
+        }
+        getByName("test") {
+            java.srcDirs("../dP256/src/test/kotlin")
+            resources.srcDirs("../dP256/src/test/resources")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    // Keep dependencies aligned with the JVM module so behavior matches.
+    implementation("cash.z.ecc.android:kotlin-bip39:1.0.8")
+    implementation("org.bouncycastle:bcprov-jdk15on:1.70")
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    api("org.apache.commons:commons-math3:3.6.1")
+    implementation("com.google.guava:guava:31.0.1-jre")
+}
+
+// Android unit tests still run on the JVM.
+tasks.withType<Test> {
+    useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+    }
+}

--- a/dP256Android/consumer-rules.pro
+++ b/dP256Android/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Consumer ProGuard rules for deterministic P-256 library.
+# (Intentionally empty; add keep rules here if you ship a minified app and hit reflection/crypto issues.)

--- a/dP256Android/src/main/AndroidManifest.xml
+++ b/dP256Android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,11 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        google()
         mavenCentral()
     }
 }
 
 rootProject.name = "foundation.algorand.deterministicP256"
 include("dP256")
+include("dP256Android")


### PR DESCRIPTION
# ℹ Overview

Basically with this config you can use gradle to produce an .aar file that can be imported into e.g. react native nitro modules.

Ideally future work will integrate semantic versioning and the publishing of these artifacts to Github and Maven central. But for the time being this .aar will be pulled in through hardcoding and then as a git submodule in dp256-rn. 

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:

<!-- Use [X] to mark as completed -->

- [ ] Conventional Commits
